### PR TITLE
Refactor repository base and source to SQLAlchemy 2

### DIFF
--- a/repository/base.py
+++ b/repository/base.py
@@ -1,4 +1,5 @@
 # repos/base.py
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 class ScopedRepo:
@@ -7,13 +8,14 @@ class ScopedRepo:
         self.project_id = project_id
 
     # універсальний фільтр
-    def _scope(self, query, Model):
-        return query.filter(Model.project_id == self.project_id)
+    def _scope(self, stmt, Model):
+        return stmt.where(Model.project_id == self.project_id)
 
     # поширені методи
     def get_by_id(self, Model, item_id: int):
-        q = self.session.query(Model).filter(Model.id == item_id, Model.project_id == self.project_id)
-        return q.first()
+        stmt = select(Model).where(Model.id == item_id, Model.project_id == self.project_id)
+        return self.session.execute(stmt).scalar_one_or_none()
 
     def list_all(self, Model):
-        return self._scope(self.session.query(Model), Model).all()
+        stmt = self._scope(select(Model), Model)
+        return self.session.execute(stmt).scalars().all()


### PR DESCRIPTION
## Summary
- Switch ScopedRepo helpers to SQLAlchemy 2.0 `select` API
- Refactor SourceRep to use injected Session and `select` queries

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac9962ee5c832aae80da7230aa6423