### PR TITLE
Refactor order repository for session DI

### DIFF
--- a/repository/balance_journal_repo.py
+++ b/repository/balance_journal_repo.py
@@ -1,12 +1,14 @@
-
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from server_flask.models import BalanceJournal as SQLItem
 from domain.models.balance_journal_dto import BalanceJournalDTO as DTO
 from domain.repositories.balance_journal_repo import ItemRepository
 from infrastructure.context import current_project_id
 
+
 class BalanceJournalRepo(ItemRepository):
-    def __init__(self, session): 
+    def __init__(self, session: Session):
         self.s = session
         self.pid = current_project_id.get()
 
@@ -17,64 +19,43 @@ class BalanceJournalRepo(ItemRepository):
             income=item.income,
             total=item.total,
             balance_id=item.balance_id,
-            project_id=self.pid
-            )
+            project_id=self.pid,
+        )
         self.s.add(sql_item)
         self.s.commit()
 
-    def get_all(self, ):
-        items = self.s.query(SQLItem).filter_by(project_id=self.pid).all()
+    def get_all(self):
+        stmt = select(SQLItem).where(SQLItem.project_id == self.pid)
+        items = self.s.scalars(stmt).all()
+        return [DTO.model_validate(item) for item in items]
 
-        dtos = []
-        for item in items:
-            dto = DTO.model_validate(item)
-            # DTO(
-            #     id=item.id,
-            #     event_date=item.event_date,
-            #     desription=item.desription,
-            #     body=item.body,
-            #     income=item.income,
-            #     balance_id=item.balance_id
-            # )
-            dtos.append(dto)
-
-        return dtos
-    
     def get_all_select(self):
-        items = self.get_all() 
+        items = self.get_all()
         store_select = []
         for i in items:
-            dto = {
-                'id': i.id,
-                'name': i.name
-            }
+            dto = {"id": i.id, "name": i.name}
             store_select.append(dto)
-
         return store_select
 
-
     def get(self, item_id):
-        i = SQLItem.query.get_or_404(item_id)
-        return DTO(
-            i.id, i.name, i.api, i.token, i.token_market
-            )
-    
-    def get_by_token(self, item_token):
-        i = SQLItem.query.filter_by(token=item_token).first()
-        return DTO(
-            i.id, i.name, i.api, i.token, i.token_market
-            )
+        item = self.s.get(SQLItem, item_id)
+        return DTO(item.id, item.name, item.api, item.token, item.token_market)
 
+    def get_by_token(self, item_token):
+        stmt = select(SQLItem).where(SQLItem.token == item_token)
+        item = self.s.scalars(stmt).first()
+        return DTO(item.id, item.name, item.api, item.token, item.token_market)
 
     def update(self, item: DTO):
-        i = SQLItem.query.get_or_404(item.id)
-        i.name = item.name
-        i.api = item.api
-        i.token = item.token
-        i.token_market=item.token_market
+        instance = self.s.get(SQLItem, item.id)
+        instance.name = item.name
+        instance.api = item.api
+        instance.token = item.token
+        instance.token_market = item.token_market
         self.s.commit()
 
     def delete(self, item_id):
-        i = SQLItem.query.get_or_404(item_id)
-        self.s.delete(i)
+        instance = self.s.get(SQLItem, item_id)
+        self.s.delete(instance)
         self.s.commit()
+

--- a/repository/base.py
+++ b/repository/base.py
@@ -1,4 +1,5 @@
 # repos/base.py
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 class ScopedRepo:
@@ -7,13 +8,14 @@ class ScopedRepo:
         self.project_id = project_id
 
     # універсальний фільтр
-    def _scope(self, query, Model):
-        return query.filter(Model.project_id == self.project_id)
+    def _scope(self, stmt, Model):
+        return stmt.where(Model.project_id == self.project_id)
 
     # поширені методи
     def get_by_id(self, Model, item_id: int):
-        q = self.session.query(Model).filter(Model.id == item_id, Model.project_id == self.project_id)
-        return q.first()
+        stmt = select(Model).where(Model.id == item_id, Model.project_id == self.project_id)
+        return self.session.scalars(stmt).first()
 
     def list_all(self, Model):
-        return self._scope(self.session.query(Model), Model).all()
+        stmt = select(Model).where(Model.project_id == self.project_id)
+        return self.session.scalars(stmt).all()

--- a/repository/costumer_rep.py
+++ b/repository/costumer_rep.py
@@ -1,12 +1,14 @@
-from server_flask.models import Costumer
-from server_flask.db import db
+from sqlalchemy import select
+
+from infrastructure.models import Costumer
 from infrastructure.context import current_project_id
 
+from .base import ScopedRepo
 
 
-class CostumerRep:
-    def __init__(self):
-        self.pid = current_project_id.get()
+class CostumerRep(ScopedRepo):
+    def __init__(self, session):
+        super().__init__(session, current_project_id.get())
 
     def create(self, item_new):
         item = Costumer(
@@ -15,38 +17,42 @@ class CostumerRep:
             second_name=item_new.second_name,
             phone=item_new.phone,
             email=item_new.email,
-            project_id=self.pid
+            project_id=self.project_id,
         )
-        db.session.add(item)
-        db.session.commit()
-        db.session.refresh(item)
+        self.session.add(item)
+        self.session.commit()
+        self.session.refresh(item)
         return item
-    
+
     def read_item(self, item_id):
-        return Costumer.query.get_or_404(item_id)
-    
+        item = self.session.get(Costumer, item_id)
+        if item is None:
+            raise ValueError("Costumer not found")
+        return item
+
     def read_by_phone(self, phone):
-        phone = phone.replace('+', '')
-        return Costumer.query.filter_by(phone=phone).first()
+        phone = phone.replace("+", "")
+        stmt = select(Costumer).where(Costumer.phone == phone)
+        return self.session.scalars(stmt).first()
 
     def update(self, item_id, item_new):
         item = self.read_item(item_id)
-        item.first_name=item_new.first_name,
-        item.last_name=item_new.last_name,
-        item.second_name=item_new.second_name,
-        item.phone=item_new.phone,
-        item.email=item_new.email
-        db.session.commit()
-        db.session.refresh(item)
+        item.first_name = item_new.first_name
+        item.last_name = item_new.last_name
+        item.second_name = item_new.second_name
+        item.phone = item_new.phone
+        item.email = item_new.email
+        self.session.commit()
+        self.session.refresh(item)
         return item
 
     def delete(self, item_id):
         item = self.read_item(item_id)
-        db.session.delete(item)
-        db.session.commit()
+        self.session.delete(item)
+        self.session.commit()
         return True
 
     def read_all(self):
-        return Costumer.query.all()
-        
-    
+        stmt = select(Costumer)
+        return self.session.scalars(stmt).all()
+

--- a/repository/delivery_order_rep.py
+++ b/repository/delivery_order_rep.py
@@ -1,10 +1,15 @@
-from server_flask.db import db
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
 from server_flask.models import DeliveryOrder
 from infrastructure.context import current_project_id
 
-class DeliveryOrderRep:
-    def __init__(self):
-        self.pid = current_project_id.get()
+from .base import ScopedRepo
+
+
+class DeliveryOrderRep(ScopedRepo):
+    def __init__(self, session: Session):
+        super().__init__(session, current_project_id.get())
 
     def add_item(self, order_id, status):
         item = DeliveryOrder(
@@ -13,67 +18,71 @@ class DeliveryOrderRep:
             number_registr="-",
             order_id=order_id,
             status_id=status,
-            project_id=self.pid
+            project_id=self.project_id,
         )
-        db.session.add(item)
-        db.session.commit()
-        # db.session.close()
+        self.session.add(item)
+        self.session.commit()
         return True
 
     def load_item(self, order_id):
-        item = DeliveryOrder.query.filter_by(order_id=order_id).first()
-        return item
+        stmt = select(DeliveryOrder).where(
+            DeliveryOrder.order_id == order_id,
+            DeliveryOrder.project_id == self.project_id,
+        )
+        return self.session.scalars(stmt).first()
 
     def update_ttn(self, order_id, data):
         order = self.load_item(order_id)
         if not order:
             self.add_item(order_id, 1)
             order = self.load_item(order_id)
-        order.ref_ttn = data["ref_ttn"],
+        order.ref_ttn = data["ref_ttn"]
         order.number_ttn = data["number_ttn"]
-        db.session.commit()
-        # db.session.close()
+        self.session.commit()
         return True
 
     def update_registr(self, items, data):
-        for item in items:
-            item = self.load_item(item)
-            print(f"update registr {item}, {data}")
+        for order_id in items:
+            item = self.load_item(order_id)
             item.ref_registr = data["ref_registr"]
             item.number_registr = data["number_registr"]
-            db.session.commit()
-        # db.session.close()
+        self.session.commit()
         return True
 
     def reg_delete_in_item(self, items):
-        for item in items:
-            v = self.load_item(item)
-            v.ref_registr = ''
-            v.number_registr = ''
-            db.session.commit()
-        # db.session.close()
+        for order_id in items:
+            v = self.load_item(order_id)
+            v.ref_registr = ""
+            v.number_registr = ""
+        self.session.commit()
         return True
 
     def load_item_filter_order(self, data):
         order_list = []
-        print(data)
         for order_id in data:
-            print(order_id)
-            order = DeliveryOrder.query.filter_by(order_id=int(order_id)).first()
-            order_list.append(order)
+            stmt = select(DeliveryOrder).where(
+                DeliveryOrder.order_id == int(order_id),
+                DeliveryOrder.project_id == self.project_id,
+            )
+            order_list.append(self.session.scalars(stmt).first())
         return order_list
 
     def load_order_for_ref(self, number_ttn):
-        order = DeliveryOrder.query.filter_by(number_ttn=number_ttn).first()
-        return order
+        stmt = select(DeliveryOrder).where(
+            DeliveryOrder.number_ttn == number_ttn,
+            DeliveryOrder.project_id == self.project_id,
+        )
+        return self.session.scalars(stmt).first()
 
     def load_registred(self):
-        item = DeliveryOrder.query.filter(
-            DeliveryOrder.orders.ordered_status_id == 11,
-            DeliveryOrder.orders.delivery_method_id == 1
-                                   ).all()
-        return item
-
-
-
+        stmt = (
+            select(DeliveryOrder)
+            .join(DeliveryOrder.orders)
+            .where(
+                DeliveryOrder.orders.ordered_status_id == 11,
+                DeliveryOrder.orders.delivery_method_id == 1,
+                DeliveryOrder.project_id == self.project_id,
+            )
+        )
+        return self.session.scalars(stmt).all()
 

--- a/repository/money_jour_rep.py
+++ b/repository/money_jour_rep.py
@@ -1,62 +1,71 @@
-from server_flask.db import db
+from sqlalchemy import desc, select
+from sqlalchemy.orm import Session
+
 from server_flask.models import MoneyJournal
-from sqlalchemy import desc
 from domain.models.money_jour_dto import MoneyJournalDto
 from infrastructure.context import current_project_id
 
-class JourChRep:
-    def __init__(self):
-        self.pid = current_project_id.get()
-        
+from .base import ScopedRepo
+
+
+class MoneyJourRep(ScopedRepo):
+    def __init__(self, session: Session):
+        super().__init__(session, current_project_id.get())
+
     def load_all(self):
-        items = MoneyJournal.query.order_by(desc(MoneyJournal.timestamp)).all()
-        items_dto = []
-        for item in items:
-            items_dto.append(
-                MoneyJournalDto(
-                    id=item.id,
-                    timestamp=item.timestamp,
-                    event_date=item.event_date,
-                    description=item.description,
-                    movement=item.movement,
-                    total=item.total
-                )
-                )
-        return items_dto
+        stmt = (
+            select(MoneyJournal)
+            .where(MoneyJournal.project_id == self.project_id)
+            .order_by(desc(MoneyJournal.timestamp))
+        )
+        items = self.session.scalars(stmt).all()
+        return [
+            MoneyJournalDto(
+                id=item.id,
+                timestamp=item.timestamp,
+                event_date=item.event_date,
+                description=item.description,
+                movement=item.movement,
+                total=item.total,
+            )
+            for item in items
+        ]
 
     def add_(self, dto: MoneyJournalDto):
         try:
             item = MoneyJournal(
-                    event_date=dto.event_date,
-                    description=dto.description,
-                    movement=dto.movement,
-                    total=dto.total,
-                    project_id=self.pid
-                )
-            db.session.add(item)
-            db.session.commit()
+                event_date=dto.event_date,
+                description=dto.description,
+                movement=dto.movement,
+                total=dto.total,
+                project_id=self.project_id,
+            )
+            self.session.add(item)
+            self.session.commit()
             return True
         except Exception as e:
-            ValueError(f"Помилка додавання в бд {e}")
+            raise ValueError(f"Помилка додавання в бд {e}")
 
-    def update_(self, id, dto):
+    def update_(self, item_id, dto: MoneyJournalDto):
         try:
-            instance = MoneyJournal.query.get_or_404(id)
+            instance = self.get_by_id(MoneyJournal, item_id)
+            if not instance:
+                return None
             instance.event_date = dto.event_date
             instance.description = dto.description
             instance.movement = dto.movement
             instance.total = dto.total
-            db.session.commit()
-            db.session.refresh()
+            self.session.commit()
+            self.session.refresh(instance)
             return instance
         except Exception as e:
-            ValueError(f"Помилка оновленя в бд {e}")
+            raise ValueError(f"Помилка оновленя в бд {e}")
 
-    def delete_(self, id):
-        task_to_delete = MoneyJournal.query.get_or_404(id)
-        print(">>> Start delete in datebase")
-        db.session.delete(task_to_delete)
-        db.session.commit()
-        print(">>> Delete in datebase")
+    def delete_(self, item_id):
+        item = self.get_by_id(MoneyJournal, item_id)
+        if not item:
+            return False
+        self.session.delete(item)
+        self.session.commit()
         return True
 

--- a/repository/product_analitic_rep.py
+++ b/repository/product_analitic_rep.py
@@ -1,91 +1,103 @@
-from server_flask.models import ProductAnalitic, Products, OrderedProduct 
-from server_flask.models import SourceDifference
 from datetime import datetime, timedelta
-from server_flask.db import db
-# from server_flask.models import Users, Orders, FinancAnalitic
-from sqlalchemy import func
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from server_flask.models import OrderedProduct, ProductAnalitic, Products
 from infrastructure import current_project_id
 
-class ProductAnaliticRep():
-    def __init__(self):
-        self.pid = current_project_id.get()
+from .base import ScopedRepo
 
-    def body_product_price(self, product_id):
-        body_price = db.session.query(Products.body_product_price).filter(Products.id == product_id).scalar()
-        return body_price
 
-    def quantity_product(self, product_id):
-        quantity = db.session.query(Products.quantity).filter(Products.id == product_id).scalar()
-        return quantity
+class ProductAnaliticRep(ScopedRepo):
+    def __init__(self, session: Session):
+        super().__init__(session, current_project_id.get())
 
-    def update_product_analitic(self, *args):
-        try:
-            item = ProductAnalitic.query.filter_by(product_id=args[0]).first()
-            item.money_in_product = args[1]
-            item.quantity_sale = args[2]
-            item.money_in_sale = args[3]
-            db.session.commit()
-            return True
-        except:
+    def body_product_price(self, product_id: int):
+        stmt = select(Products.body_product_price).where(
+            Products.id == product_id,
+            Products.project_id == self.project_id,
+        )
+        return self.session.scalar(stmt)
+
+    def quantity_product(self, product_id: int):
+        stmt = select(Products.quantity).where(
+            Products.id == product_id,
+            Products.project_id == self.project_id,
+        )
+        return self.session.scalar(stmt)
+
+    def update_product_analitic(self, product_id: int, money_prod, qty_sale, money_sale):
+        stmt = select(ProductAnalitic).where(
+            ProductAnalitic.product_id == product_id,
+            ProductAnalitic.project_id == self.project_id,
+        )
+        item = self.session.scalars(stmt).first()
+        if not item:
             return False
+        item.money_in_product = money_prod
+        item.quantity_sale = qty_sale
+        item.money_in_sale = money_sale
+        self.session.commit()
+        return True
 
-    def item_product_analitic(self, product_id):
-        item = ProductAnalitic.query.filter_by(product_id=product_id).first()
-        return item
+    def item_product_analitic(self, product_id: int):
+        stmt = select(ProductAnalitic).where(
+            ProductAnalitic.product_id == product_id,
+            ProductAnalitic.project_id == self.project_id,
+        )
+        return self.session.scalars(stmt).first()
 
     def all_product_analitic(self):
-        item_all = ProductAnalitic.query.order_by(ProductAnalitic.timestamp.desc()).all()
-        return item_all
+        stmt = (
+            select(ProductAnalitic)
+            .where(ProductAnalitic.project_id == self.project_id)
+            .order_by(ProductAnalitic.timestamp.desc())
+        )
+        return self.session.scalars(stmt).all()
 
-    def add_product_analitic(self, product_id):
-        try:
-            print("СРАБОТАЛ АПДЕЙТ АНАЛІТІК")
-            prod_analitic = ProductAnalitic(
-                product_id=product_id,
-                project_id=self.pid
-                                            )
-            db.session.add(prod_analitic)
-            db.session.commit()
-        except:
-            return False
+    def add_product_analitic(self, product_id: int):
+        prod_analitic = ProductAnalitic(
+            product_id=product_id, project_id=self.project_id
+        )
+        self.session.add(prod_analitic)
+        self.session.commit()
+        return True
 
-    def search_an_product_id(self, product_id):
-        prod_an_item = ProductAnalitic.query.filter_by(product_id=product_id).first()
-        return prod_an_item
+    def search_an_product_id(self, product_id: int):
+        return self.item_product_analitic(product_id)
 
-    def get_sum_product_sale(self, product_id):
-        sum_product_sale = db.session.query(func.sum(OrderedProduct.quantity)).filter(OrderedProduct.product_id == product_id).scalar()
-        if not sum_product_sale:
-            sum_product_sale = 0
-        return sum_product_sale
+    def get_sum_product_sale(self, product_id: int):
+        stmt = select(func.sum(OrderedProduct.quantity)).where(
+            OrderedProduct.product_id == product_id,
+            OrderedProduct.project_id == self.project_id,
+        )
+        return self.session.scalar(stmt) or 0
 
     def get_money_sale_day(self):
         current_time = datetime.now()
-        print(f"current_time {current_time}")
         start_time = current_time - timedelta(days=1)
         start_time = start_time.replace(hour=17, minute=0, second=0, microsecond=0)
-        money_sale = (db.session.query(func.count(ProductAnalitic.money_in_sale))
-                      .filter(ProductAnalitic.timestamp >= start_time,
-                        ProductAnalitic.timestamp <= current_time).scalar())
-        return money_sale
+        stmt = select(func.count(ProductAnalitic.money_in_sale)).where(
+            ProductAnalitic.timestamp >= start_time,
+            ProductAnalitic.timestamp <= current_time,
+            ProductAnalitic.project_id == self.project_id,
+        )
+        return self.session.scalar(stmt)
 
-    def delete_item(self, id):
-        task_to_delete = ProductAnalitic.query.get_or_404(id)
-        print(">>> Start delete in datebase")
-        db.session.delete(task_to_delete)
-        db.session.commit()
-        print(">>> Delete in datebase")
+    def delete_item(self, item_id: int):
+        item = self.get_by_id(ProductAnalitic, item_id)
+        if not item:
+            return False
+        self.session.delete(item)
+        self.session.commit()
         return True
 
     def load_prod_order(self):
-        items = OrderedProduct.query.order_by(OrderedProduct.timestamp.desc()).all
-        return items
-    
-    
-
-
-
-
-
-
+        stmt = (
+            select(OrderedProduct)
+            .where(OrderedProduct.project_id == self.project_id)
+            .order_by(OrderedProduct.timestamp.desc())
+        )
+        return self.session.scalars(stmt).all()
 

--- a/repository/product_rep.py
+++ b/repository/product_rep.py
@@ -1,187 +1,160 @@
-from server_flask.db import db
-from server_flask.models import (Products,
-                                 ProductAnalitic,
-                                 ProductRelate,
-                                 ProductSource)
-from utils import OC_logger
 from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from server_flask.models import ProductAnalitic, ProductRelate, Products
+from utils import OC_logger
 from infrastructure import current_project_id
+
+from .base import ScopedRepo
+
 
 @dataclass
 class ProductRelateDTO:
     id: int
-    product_id: int 
+    product_id: int
     quantity: int
     product_source_id: int
 
-class ProductRep():
-    def __init__(self):
-        self.log = OC_logger.oc_log('prod_rep')
-        self.pid = current_project_id.get()
+
+class ProductRep(ScopedRepo):
+    def __init__(self, session: Session):
+        super().__init__(session, current_project_id.get())
+        self.log = OC_logger.oc_log("prod_rep")
 
     def add_product(self, description, article, product_name, price, quantity):
         try:
-            product = Products(description=description,
-                            article=article,
-                            product_name=product_name,
-                            price=price,
-                            quantity=quantity,
-                            project_id=self.pid)
-            db.session.add(product)
-            db.session.commit()
-            add_analitic = ProductAnalitic(product_id=product.id)
-            db.session.add(add_analitic)
-            db.session.commit()
-            return True
-        except:
-            return False
-    
-    def create_v2(self, article, product_name):
-        try:
             product = Products(
-                        article=article,
-                        product_name=product_name
-                    )
-            db.session.add(product)
-            db.session.commit()
-            return product
-        except Exception as e:
-            self.log.exception(f'create_v2: {e}')
-            raise
-        
+                description=description,
+                article=article,
+                product_name=product_name,
+                price=price,
+                quantity=quantity,
+                project_id=self.project_id,
+            )
+            self.session.add(product)
+            self.session.commit()
+            add_analitic = ProductAnalitic(product_id=product.id)
+            self.session.add(add_analitic)
+            self.session.commit()
+            return True
+        except Exception:
+            return False
+
+    def create_v2(self, article, product_name):
+        product = Products(article=article, product_name=product_name, project_id=self.project_id)
+        self.session.add(product)
+        self.session.commit()
+        return product
+
     def add_product_relate(self, data_list):
         try:
             item = ProductRelate(
-                article=data_list[0], # надо поменять - ето id исходника
+                article=data_list[0],
                 product_source_id=data_list[0],
                 name="",
                 quantity=int(data_list[1]),
                 product_id=data_list[2],
             )
-            db.session.add(item)
-            db.session.commit()
-            db.session.close()
+            self.session.add(item)
+            self.session.commit()
             return True
-        except:
+        except Exception:
             return False
-        
-    def update_v2(self, id, *args):
-        try:
-            product = Products.query.get_or_404(id)
-            print(id, args)
-            product.article = args[0]
-            product.product_name = args[1]
-            db.session.commit()
-            return product
-        except:
-            return False
- 
 
-    def update_product_item(self, data, id):
-        try:
-            product = Products.query.get_or_404(id)
-            print(id, product.id, product.product_name, product.article)
-            product.article = data[0]
-            product.product_name = data[1]
-            db.session.commit()
-            return True
-        except:
+    def update_v2(self, item_id, article, product_name):
+        product = self.get_by_id(Products, item_id)
+        if not product:
             return False
-                  
-                                  
-    def update_after_arrival(self, combined_list):
-        for item in combined_list:
-            datetime_new, product_id, quantity, price, total = item
-            product = Products.query.get_or_404(product_id)
-            product.quantity = quantity + product.quantity
-            product.body_product_price = price
-            db.session.commit()
+        product.article = article
+        product.product_name = product_name
+        self.session.commit()
+        return product
+
+    def update_product_item(self, data, item_id):
+        product = self.get_by_id(Products, item_id)
+        if not product:
+            return False
+        product.article = data[0]
+        product.product_name = data[1]
+        self.session.commit()
         return True
-         
-    def delete_product(self, id):
-        task_to_delete = Products.query.get_or_404(id)
-        print(">>> Start delete in datebase")
-        db.session.delete(task_to_delete)
-        db.session.commit()
-        print(">>> Delete in datebase")
+
+    def update_after_arrival(self, combined_list):
+        for datetime_new, product_id, quantity, price, total in combined_list:
+            product = self.get_by_id(Products, product_id)
+            if product:
+                product.quantity = quantity + product.quantity
+                product.body_product_price = price
+        self.session.commit()
+        return True
+
+    def delete_product(self, item_id):
+        product = self.get_by_id(Products, item_id)
+        if not product:
+            return False
+        self.session.delete(product)
+        self.session.commit()
         return True
 
     def changeBodyPrice(self):
-        products = self.load_product_all()
-        for item in products:
+        for item in self.load_product_all():
             if not item.body_product_price:
                 item.body_product_price = 0
+        self.session.commit()
 
-    def update_product_relate(self, data, id):
-        try:
-            product = ProductRelate.query.get_or_404(id)
-
-            print(f"артикил {data}")
-            product.article = data[0]
-            product.quantity = data[1],
-            product.product_id = data[2]
-            product.product_source_id = data[0]
-            db.session.commit()
-            return True
-        except:
+    def update_product_relate(self, data, item_id):
+        product = self.get_by_id(ProductRelate, item_id)
+        if not product:
             return False
-
-    def load_product_all(self):
-        products = Products.query.order_by(Products.timestamp).all()
-        return products
-
-    def load_product_item(self, product_id):
-        product = Products.query.get_or_404(product_id)
-        return product
-    
-    def load_product_by_id(self, product_id):
-        product = Products.query.get_or_404(product_id)
-        return product
-    
-    def load_by_article(self, art):
-        try:
-            product = Products.query.filter_by(article=art).first()
-            return product
-        except:
-            return False
-
-    def load_product_relate(self):
-        products = ProductRelate.query.order_by(ProductRelate.timestamp).all()
-        return products
-
-    def load_product_relate_item(self, product_id):
-        item = ProductRelate.query.get_or_404(product_id) 
-        return item
-
-    def load_prod_relate_product_id(self, id):
-        item = ProductRelate.query.filter_by(product_id=id).first()
-        return item
-
-    def load_prod_relate_product_id_all(self, id):
-        items = ProductRelate.query.filter_by(product_id=id).all()
-        select = []
-        for i in items:
-            select.append(
-                ProductRelateDTO(
-                i.id, i.product_id, i.quantity, i.product_source_id
-            ))
-        return select
-
-
-    def delete_product_relate(self, id):
-        task_to_delete = ProductRelate.query.get_or_404(id)
-        print(">>> Start delete in datebase")
-        db.session.delete(task_to_delete)
-        db.session.commit()
-        print(">>> Delete in datebase")
+        product.article = data[0]
+        product.quantity = data[1]
+        product.product_id = data[2]
+        product.product_source_id = data[0]
+        self.session.commit()
         return True
 
+    def load_product_all(self):
+        stmt = select(Products).where(Products.project_id == self.project_id).order_by(Products.timestamp)
+        return self.session.scalars(stmt).all()
 
+    def load_product_item(self, product_id):
+        return self.get_by_id(Products, product_id)
 
+    def load_product_by_id(self, product_id):
+        return self.get_by_id(Products, product_id)
 
+    def load_by_article(self, art):
+        stmt = select(Products).where(
+            Products.article == art, Products.project_id == self.project_id
+        )
+        return self.session.scalars(stmt).first()
 
+    def load_product_relate(self):
+        stmt = select(ProductRelate).order_by(ProductRelate.timestamp)
+        return self.session.scalars(stmt).all()
 
-prod_rep = ProductRep()
+    def load_product_relate_item(self, product_id):
+        return self.get_by_id(ProductRelate, product_id)
 
+    def load_prod_relate_product_id(self, item_id):
+        stmt = select(ProductRelate).where(ProductRelate.product_id == item_id)
+        return self.session.scalars(stmt).first()
 
+    def load_prod_relate_product_id_all(self, item_id):
+        stmt = select(ProductRelate).where(ProductRelate.product_id == item_id)
+        items = self.session.scalars(stmt).all()
+        return [
+            ProductRelateDTO(i.id, i.product_id, i.quantity, i.product_source_id)
+            for i in items
+        ]
+
+    def delete_product_relate(self, item_id):
+        item = self.get_by_id(ProductRelate, item_id)
+        if not item:
+            return False
+        self.session.delete(item)
+        self.session.commit()
+        return True
 

--- a/repository/sour_difference_an_rep.py
+++ b/repository/sour_difference_an_rep.py
@@ -1,146 +1,173 @@
+import copy
+
+from sqlalchemy import desc, select
+from sqlalchemy.orm import Session
 
 from server_flask.models import SourceDifference
-from server_flask.db import db
-from sqlalchemy import desc
-import copy
 from infrastructure import current_project_id
 
+from .base import ScopedRepo
 
-  
 
-class SourDiffAnRep():
-    def __init__(self) -> None:
-        self.pid = current_project_id.get()
+class SourDiffAnRep(ScopedRepo):
+    def __init__(self, session: Session):
+        super().__init__(session, current_project_id.get())
 
     def add_source_difference(self, body):
         try:
-            add = SourceDifference(event_date=body[0], 
-                                   source_id=body[1],
-                                   quantity_crm=body[2],
-                                   quantity_stock=body[3],
-                                   difference=body[4]
-                                   )
-            db.session.add(add)
-            db.session.commit() 
+            add = SourceDifference(
+                event_date=body[0],
+                source_id=body[1],
+                quantity_crm=body[2],
+                quantity_stock=body[3],
+                difference=body[4],
+                project_id=self.project_id,
+            )
+            self.session.add(add)
+            self.session.commit()
             return add
-        except:
-            return False  
+        except Exception:
+            return False
 
     def add_quantity_crm(self, body):
         try:
             add = SourceDifference(
-                event_date=body[0], 
+                event_date=body[0],
                 source_id=body[1],
-                quantity_crm=body[2]
-                                   )
-            db.session.add(add)
-            db.session.commit() 
+                quantity_crm=body[2],
+                project_id=self.project_id,
+            )
+            self.session.add(add)
+            self.session.commit()
             return add
-        except:
+        except Exception:
             return False
 
-    def add_diff_comment(self, id, comment: str):
+    def add_diff_comment(self, item_id, comment: str):
         try:
-            line = self.load_source_diff_line(id)
+            line = self.load_source_diff_line(item_id)
             line.comment = f"{line.comment} \n {comment}" if line.comment else comment
-            db.session.commit()
+            self.session.commit()
             return True
         except Exception as e:
             return ValueError(e)
- 
+
     def load_source_difference(self):
-        product = SourceDifference.query.all() #.query.order_by(ProductDifference.timestamp.desc()).all 
-        return product
-    
-    def load_source_diff_line(self, id):
-        line = SourceDifference.query.get_or_404(id)
-        return line
-          
+        stmt = select(SourceDifference).where(
+            SourceDifference.project_id == self.project_id
+        )
+        return self.session.scalars(stmt).all()
+
+    def load_source_diff_line(self, item_id):
+        return self.get_by_id(SourceDifference, item_id)
+
     def load_source_difference_period(self, start, stop):
-        product = SourceDifference.query.filter(
-            SourceDifference.event_date >= start,
-            SourceDifference.event_date <= stop
-        ).order_by(desc(SourceDifference.timestamp)).all()
-        return product
-  
-    def load_source_difference_id_period(self, id, start, stop):
-        product = SourceDifference.query.filter(
-            SourceDifference.event_date >= start,
-            SourceDifference.event_date <= stop,
-            SourceDifference.source_id == id
-        ).order_by(desc(SourceDifference.timestamp)).all()
-        return product
-    
+        stmt = (
+            select(SourceDifference)
+            .where(
+                SourceDifference.event_date >= start,
+                SourceDifference.event_date <= stop,
+                SourceDifference.project_id == self.project_id,
+            )
+            .order_by(desc(SourceDifference.timestamp))
+        )
+        return self.session.scalars(stmt).all()
+
+    def load_source_difference_id_period(self, source_id, start, stop):
+        stmt = (
+            select(SourceDifference)
+            .where(
+                SourceDifference.event_date >= start,
+                SourceDifference.event_date <= stop,
+                SourceDifference.source_id == source_id,
+                SourceDifference.project_id == self.project_id,
+            )
+            .order_by(desc(SourceDifference.timestamp))
+        )
+        return self.session.scalars(stmt).all()
+
     def load_last_line_id(self, source_id: int):
-        source = SourceDifference.query.filter_by(source_id=source_id).order_by(desc(SourceDifference.timestamp)).first()
-        return source
-         
-    def update_source_difference(self, *args):
+        stmt = (
+            select(SourceDifference)
+            .where(
+                SourceDifference.source_id == source_id,
+                SourceDifference.project_id == self.project_id,
+            )
+            .order_by(desc(SourceDifference.timestamp))
+        )
+        return self.session.scalars(stmt).first()
+
+    def update_source_difference(self, source_id, quantity_crm, quantity_stock):
         try:
-            item = SourceDifference.query.filter_by(source_id=args[0]).first()
-            item.quantity_crm = args[1]
-            item.quantity_stock = args[2]
-            db.session.commit()
+            stmt = select(SourceDifference).where(
+                SourceDifference.source_id == source_id,
+                SourceDifference.project_id == self.project_id,
+            )
+            item = self.session.scalars(stmt).first()
+            if not item:
+                return False
+            item.quantity_crm = quantity_crm
+            item.quantity_stock = quantity_stock
+            self.session.commit()
             return True
-        except:
+        except Exception:
             return False
 
-    def update_source_diff_line(self, args, id):
+    def update_source_diff_line(self, args, item_id):
         try:
-            item = SourceDifference.query.get_or_404(id)
+            item = self.load_source_diff_line(item_id)
             item.quantity_crm = args[0]
             item.quantity_stock = args[1]
-            db.session.commit()
+            self.session.commit()
             return True
-        except:
+        except Exception:
             return False
-    
-    def update_source_diff_line_sold(self, quantity, id):
+
+    def update_source_diff_line_sold(self, quantity, item_id):
         try:
-            item = SourceDifference.query.get_or_404(id)
+            item = self.load_source_diff_line(item_id)
             item.sold = quantity
-            db.session.commit()
+            self.session.commit()
             return True
-        except:
+        except Exception:
             return False
-          
-    def update_diff_sum(self, id, quantity):
+
+    def update_diff_sum(self, item_id, quantity):
         try:
-            item = SourceDifference.query.get_or_404(id)
+            item = self.load_source_diff_line(item_id)
             item.difference = quantity
-            db.session.commit()
+            self.session.commit()
             return True
-        except:
+        except Exception:
             return False
-       
-               
-    def update_diff_table(self, data): # update quantity_stock
+
+    def update_diff_table(self, data):
         try:
             for row in data:
                 item = self.load_source_diff_line(row[0])
                 item.quantity_stock = row[1]
-                db.session.commit()
+            self.session.commit()
             return True
-        except:
+        except Exception:
             return False
-        
-    def update_quantity_crm(self, data): # update quantity_stock
+
+    def update_quantity_crm(self, data):
         try:
             for row in data:
                 item = self.load_source_diff_line(row[0])
                 item.quantity_crm = row[1]
-                db.session.commit()
+            self.session.commit()
             return True
-        except:
+        except Exception:
             return False
-        
-    def delete_diff_line(self, id):
+
+    def delete_diff_line(self, item_id):
         try:
-            item = self.load_source_diff_line(id)
+            item = self.load_source_diff_line(item_id)
             item_copy = copy.deepcopy(item)
-            print(item_copy.source_id, "item_copy")
-            db.session.delete(item)
-            db.session.commit()
+            self.session.delete(item)
+            self.session.commit()
             return True, item_copy.source_id
-        except:
+        except Exception:
             return False
+


### PR DESCRIPTION
## Summary
- refactor remaining repositories to subclass `ScopedRepo` and accept injected SQLAlchemy `Session`
- replace Flask-SQLAlchemy patterns with SQLAlchemy 2.0 `select()` queries across product, receipt, token, journal, delivery, money, source diff, product, and balance journal repositories

## Testing
- `python -m py_compile repository/product_analitic_rep.py repository/receipt_rep.py repository/user_token_rep.py repository/jour_ch_rep.py repository/delivery_order_rep.py repository/money_jour_rep.py repository/sour_difference_an_rep.py repository/product_rep.py repository/balance_journal_repo.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aca0515a0c832a8b0b62edbaa5bc6a